### PR TITLE
chore: add service favicon

### DIFF
--- a/Web/favicon.svg
+++ b/Web/favicon.svg
@@ -1,0 +1,11 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+  <rect width="100" height="100" rx="22" fill="#164E63"/>
+  <text x="50" y="50"
+    font-family="system-ui,-apple-system,'Segoe UI','Helvetica Neue',Arial,sans-serif"
+    font-size="46"
+    font-weight="800"
+    fill="#FFFFFF"
+    text-anchor="middle"
+    dominant-baseline="central"
+    letter-spacing="-1">Vc</text>
+</svg>

--- a/Web/index.html
+++ b/Web/index.html
@@ -4,6 +4,7 @@
 <link rel="apple-touch-icon" href="/icon.png"></link>
 <meta name="theme-color" content="#fff" />
 <meta charset="UTF-8">
+    <link rel="icon" type="image/svg+xml" href="./favicon.svg">
 <meta name="viewport" content="width=device-width, initial-scale=1.0 user-scalable=no">
 <title>VANTAN -o- CONNECT</title>
 <link href="https://unpkg.com/nes.css/css/nes.css" rel="stylesheet" />


### PR DESCRIPTION
Add service favicon SVG (2-letter bold icon) for web tab visibility.

- `public/favicon.svg` を配置
- `<link rel="icon" type="image/svg+xml">` を `index.html` に追加

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Added a custom favicon that now appears in browser tabs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->